### PR TITLE
(feature) Deny access to dashboard when user is not logged in

### DIFF
--- a/app/urls.py
+++ b/app/urls.py
@@ -3,11 +3,13 @@ from django.conf.urls import url, include
 from rest_framework import routers
 
 from . import viewsets
+from . import views
 
 router = routers.DefaultRouter()
 router.register(r'photos', viewsets.PhotoViewSet, 'photos')
 router.register(r'effects', viewsets.EffectViewSet, 'effects')
 
 urlpatterns = [
-	url(r'^', include(router.urls))
+	url(r'^', include(router.urls)),
+    url(r'^loginstatus', views.is_logged_in, name='loginstatus')
 ]

--- a/app/views.py
+++ b/app/views.py
@@ -1,7 +1,28 @@
 from django.shortcuts import render
 
+from rest_framework import status
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
 
 # Create your views here.
 def index(request):
 	"""Display the login template."""
 	return render(request, 'views/angular_base.html', {'request': request})
+
+@api_view(['GET'])
+def is_logged_in(request):
+    """Method view to check if request is coming from a user who is logged in
+    through a Django backends authentication system."""
+    if request.method == 'GET':
+        if request.user.is_authenticated():
+            return Response(
+                {
+                    'status': 'isLoggedIn'
+                }, status=status.HTTP_200_OK
+            )
+        return Response(
+            {
+                'status': 'notLoggedIn'
+            }, status=status.HTTP_401_UNAUTHORIZED
+        )

--- a/public/static/js/controllers/DashboardController.js
+++ b/public/static/js/controllers/DashboardController.js
@@ -1,6 +1,6 @@
 vistagrid.controller('DashboardController',
-	['$scope', 'PhotoService', 'Upload', 'FacebookService', '$rootScope', '$location',
-	function ($scope, PhotoService, Upload, FacebookService, $rootScope, $location) {
+	['$scope', 'PhotoService', 'Upload', 'AuthService', '$rootScope', '$location',
+	function ($scope, PhotoService, Upload, AuthService, $rootScope, $location) {
 		var clickedPhotoID = null;
 
 		var fetchUploads = function () {
@@ -16,14 +16,13 @@ vistagrid.controller('DashboardController',
 
 		var checkLogin = function () {
 			console.log('Checking login credentials!');
-			FacebookService.loginStatus().then(
+			AuthService.loginStatus.get().$promise.then(
 				function (response) {
-					console.log(response);
 					fetchUploads();
 				},
 				function (error) {
 					$location.path('/');
-					var $toastContent = $('<span style="font-weight: bold">Facebook login required.</span>');
+					var $toastContent = $('<span style="font-weight: bold">Please login via Facebook.</span>');
 					Materialize.toast($toastContent, 5000);
 				}
 			);

--- a/public/static/js/services/AuthService.js
+++ b/public/static/js/services/AuthService.js
@@ -1,0 +1,11 @@
+vistagrid.factory('AuthService', ['$resource',
+    function ($resource) {
+        return {
+            loginStatus: $resource('/api/loginstatus/', {}, {
+                get: {
+                    method: 'GET',
+                    isArray: false
+                }
+            })
+        }
+}]);


### PR DESCRIPTION
- Create a view to check the authenticated status from the request
  object to determine if a user is logged in or not
- If user is not logged in and attempts to access the dashboard, they
  will be redirected to login with a message informing them that they
  need to authenticate via Facebook
- Create route to access is_logged_in method view
- Create an AuthService that will query the loginstatus and provide
  the response that will be used to determine whether the app should
  redirect to login
